### PR TITLE
Implement entrypoint run function

### DIFF
--- a/wyoming_satellite/__main__.py
+++ b/wyoming_satellite/__main__.py
@@ -439,8 +439,12 @@ def _split(command: Optional[str]) -> Optional[List[str]]:
 
 # -----------------------------------------------------------------------------
 
-if __name__ == "__main__":
+def run():
     try:
         asyncio.run(main())
     except KeyboardInterrupt:
         pass
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
Because otheriwse we run into

```
AttributeError: module 'wyoming_satellite.__main__' has no attribute 'run'
```