### PR TITLE
fix: add sounds dir to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
 
 WORKDIR /app
 
+COPY sounds/ ./sounds/
 COPY script/setup ./script/
 COPY setup.py requirements.txt MANIFEST.in ./
 COPY wyoming_satellite/ ./wyoming_satellite/


### PR DESCRIPTION
Just adding the sounds/ folder into the container. This lets folks use the default sounds without having to mount a directory / download sounds.

## Testing:
Working with this config:

```
version: '3.8'
services:
  playback:
    container_name: wyoming-snd-external
    build: https://github.com/rhasspy/wyoming-snd-external.git
    image: wyoming-snd-external
    restart: unless-stopped
    ports:
      - "10601:10601"
    devices:
      - /dev/snd:/dev/snd
    group_add:
      - audio
    command: 
      - "--device"
      - "plughw:CARD=Headphones"
      - "--debug"
  microphone:
    container_name: wyoming-mic-external
    build: https://github.com/rhasspy/wyoming-mic-external.git
    image: wyoming-mic-external
    restart: unless-stopped
    ports: 
      - "10600:10600"
    devices:
      - /dev/snd:/dev/snd
    group_add:
      - audio
    depends_on:
      - satellite
    command:
      - "--device"
      - "plughw:CARD=seeed4micvoicec"
      - "--debug"
  satellite:
    container_name: wyoming-satellite
    build: https://github.com/graimalkin/wyoming-satellite.git#fix--add-sounds-in-docker-container
    # build: https://github.com/rhasspy/wyoming-satellite.git
    image: wyoming-satellite
    hostname: office
    restart: unless-stopped
    ports:
      - "10700:10700"
    command:
      - "--name"
      - "office"
      - "--uri"
      - "tcp://0.0.0.0:10700"
      - "--mic-uri"
      - "tcp://microphone:10600"
      - "--snd-uri"
      - "tcp://playback:10601"
      - "--debug"
      - "--awake-wav"
      - "sounds/awake.wav"
      - "--done-wav"
      - "sounds/done.wav"
      - "--wake-uri"
      - "tcp://myopenwakewordserver:10400"   <-- you'll want to change this if you're validating it :P
```