### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,6 @@
 !script/setup
 !script/run
 !wyoming_satellite/*.py
+!wyoming_satellite/VERSION
 !docker/run
 !sounds/*.wav


### PR DESCRIPTION
Due to changes in https://github.com/rhasspy/wyoming-satellite/commit/5088b590a63da61c01db78d35c259a4babaf6e53 file `VERSION` is required within the docker image and must be allowlisted in `.dockerignore`