### PR TITLE
Format log output

### DIFF
--- a/wyoming_satellite/__main__.py
+++ b/wyoming_satellite/__main__.py
@@ -39,6 +39,12 @@ _DIR = Path(__file__).parent
 
 async def main() -> None:
     """Main entry point."""
+
+    logging.basicConfig(
+        format='%(asctime)s %(levelname)-8s %(message)s',
+        level=logging.DEBUG,
+        datefmt='%Y-%m-%dT%H:%M:%S%z')
+
     parser = argparse.ArgumentParser()
 
     # Microphone input

--- a/wyoming_satellite/__main__.py
+++ b/wyoming_satellite/__main__.py
@@ -239,7 +239,7 @@ async def main() -> None:
 
     # configure log format
     logging.basicConfig(
-        format='%(asctime)s %(levelname)-8s %(message)s',
+        format='%(asctime)s %(levelname)-8s %(message)s' if Path("/.dockerenv").is_file() else '%(levelname)-8s %(message)s',
         level=logging.DEBUG if args.debug else logging.INFO,
         datefmt='%Y-%m-%dT%H:%M:%S%z')
 

--- a/wyoming_satellite/__main__.py
+++ b/wyoming_satellite/__main__.py
@@ -39,12 +39,6 @@ _DIR = Path(__file__).parent
 
 async def main() -> None:
     """Main entry point."""
-
-    logging.basicConfig(
-        format='%(asctime)s %(levelname)-8s %(message)s',
-        level=logging.DEBUG,
-        datefmt='%Y-%m-%dT%H:%M:%S%z')
-
     parser = argparse.ArgumentParser()
 
     # Microphone input
@@ -243,6 +237,12 @@ async def main() -> None:
     parser.add_argument("--debug", action="store_true", help="Log DEBUG messages")
     args = parser.parse_args()
 
+    # configure log format
+    logging.basicConfig(
+        format='%(asctime)s %(levelname)-8s %(message)s',
+        level=logging.DEBUG if args.debug else logging.INFO,
+        datefmt='%Y-%m-%dT%H:%M:%S%z')
+
     # Validate args
     if (not args.mic_uri) and (not args.mic_command):
         _LOGGER.fatal("Either --mic-uri or --mic-command is required")
@@ -273,7 +273,6 @@ async def main() -> None:
     if args.vad and (args.wake_uri or args.wake_command):
         _LOGGER.warning("VAD is not used with local wake word detection")
 
-    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
     _LOGGER.debug(args)
 
     if args.debug_recording_dir:


### PR DESCRIPTION
Make logs easier to interpret by prefixing with a timestamp and formatting log level and message (tabbed display). Output from mic/snd commands (arecord/aplay) or openwakeword of course will not be affected.

before

```
INFO:root:Ready
INFO:root:Connected to services
Recording raw data 'stdin' : Signed 16 bit Little Endian, Rate 16000 Hz, Mono
INFO:root:Connected to server
INFO:root:Waiting for speech
```

after

```
2024-01-19T21:40:10+0000 INFO     Ready
2024-01-19T21:40:10+0000 INFO     Connected to services
Recording raw data 'stdin' : Signed 16 bit Little Endian, Rate 16000 Hz, Mono
2024-01-19T21:40:21+0000 INFO     Connected to server
2024-01-19T21:40:21+0000 INFO     Waiting for speech
```

after (with debug turned on)

```
2024-01-19T21:41:12+0000 DEBUG    Running ['/commands/startup.sh']
2024-01-19T21:41:12+0000 INFO     Ready
2024-01-19T21:41:12+0000 DEBUG    Detected IP: 172.25.0.5
2024-01-19T21:41:13+0000 DEBUG    Zeroconf discovery enabled (name=0242ac190005, host=None)
2024-01-19T21:41:13+0000 DEBUG    Connecting to mic service: ['arecord', '-D', 'plughw:CARD=USB,DEV=0', '-r', '16000', '-c', '1', '-f', 'S16_LE', '-t', 'raw']
2024-01-19T21:41:13+0000 DEBUG    Connecting to snd service: ['aplay', '-D', 'plughw:CARD=USB,DEV=0', '-r', '22050', '-c', '1', '-f', 'S16_LE', '-t', 'raw']
2024-01-19T21:41:13+0000 INFO     Connected to services
Recording raw data 'stdin' : Signed 16 bit Little Endian, Rate 16000 Hz, Mono
2024-01-19T21:41:13+0000 DEBUG    Connected to mic service
2024-01-19T21:41:13+0000 DEBUG    Server set: 18071130101696359
2024-01-19T21:41:13+0000 INFO     Connected to server
2024-01-19T21:41:13+0000 INFO     Waiting for speech
```