### PR TITLE
Awake wav mic mute settings

### DIFF
--- a/wyoming_satellite/__main__.py
+++ b/wyoming_satellite/__main__.py
@@ -73,6 +73,16 @@ async def main() -> None:
         "--mic-noise-suppression", type=int, default=0, choices=(0, 1, 2, 3, 4)
     )
     parser.add_argument("--mic-auto-gain", type=int, default=0, choices=list(range(32)))
+    parser.add_argument(
+        "--mic-seconds-to-mute-after-awake-wav", 
+        type=float, 
+        default=0.5, 
+        help="Seconds to mute after awake wav is played")
+    parser.add_argument(
+        "--mic-mute-during-awake-wav", 
+        type=bool, 
+        default=True, 
+        help="Determine if mic should be muted while awake wav is played")
 
     # Sound output
     parser.add_argument("--snd-uri", help="URI of Wyoming sound service")
@@ -301,6 +311,8 @@ async def main() -> None:
             volume_multiplier=args.mic_volume_multiplier,
             auto_gain=args.mic_auto_gain,
             noise_suppression=args.mic_noise_suppression,
+            seconds_to_mute_after_awake_wav=args.mic_seconds_to_mute_after_awake_wav,
+            mute_during_awake_wav=args.mic_mute_during_awake_wav
         ),
         vad=VadSettings(
             enabled=args.vad,


### PR DESCRIPTION
Adds two new settings:
- "--mic-seconds-to-mute-after-awake-wav" - seconds to mute mic after awake wav is played.
- "--mic-mute-during-awake-wav" - true/false if mic should be muted while awake-wav is played.