### PR TITLE
Expose Played command

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ Satellites can respond to events from the server by running commands:
 * `--stt-start-command` - user started speaking (no stdin)
 * `--stt-stop-command` - user stopped speaking (no stdin)
 * `--synthesize-command` - text-to-speech text is returned (text on stdin)
-* `--tts-start-command` - text-to-speech response started (no stdin)
-* `--tts-stop-command` - text-to-speech response stopped (no stdin)
-* `--played-command` - text-to-speech response was played (no stdin)
+* `--tts-start-command` - text-to-speech response started streaming from server (no stdin)
+* `--tts-stop-command` - text-to-speech response stopped streaming from server. Can still being played by snd service (no stdin)
+* `--played-command` - text-to-speech audio finished playing (no stdin)
 * `--error-command` - an error was sent from the server (text on stdin)
 * `--connected-command` - satellite connected to server
 * `--disconnected-command` - satellite disconnected from server

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Satellites can respond to events from the server by running commands:
 * `--synthesize-command` - text-to-speech text is returned (text on stdin)
 * `--tts-start-command` - text-to-speech response started (no stdin)
 * `--tts-stop-command` - text-to-speech response stopped (no stdin)
+* `--played-command` - text-to-speech response was played (no stdin)
 * `--error-command` - an error was sent from the server (text on stdin)
 * `--connected-command` - satellite connected to server
 * `--disconnected-command` - satellite disconnected from server

--- a/wyoming_satellite/__main__.py
+++ b/wyoming_satellite/__main__.py
@@ -159,6 +159,9 @@ async def main() -> None:
         "--detection-command", help="Command to run when wake word is detected"
     )
     parser.add_argument(
+        "--played-command", help="Command to run when audio stopped playing"
+    )
+    parser.add_argument(
         "--transcript-command",
         help="Command to run when speech to text transcript is returned",
     )
@@ -334,6 +337,7 @@ async def main() -> None:
             streaming_stop=split_command(args.streaming_stop_command),
             detect=split_command(args.detect_command),
             detection=split_command(args.detection_command),
+            played=split_command(args.played_command),
             transcript=split_command(args.transcript_command),
             stt_start=split_command(args.stt_start_command),
             stt_stop=split_command(args.stt_stop_command),

--- a/wyoming_satellite/satellite.py
+++ b/wyoming_satellite/satellite.py
@@ -550,7 +550,7 @@ class SatelliteBase:
                     event.type
                 ):
                     await _disconnect()
-                    await self.forward_event(Played().event())
+                    await self.trigger_played()
                     snd_client = None  # reconnect on next event
             except asyncio.CancelledError:
                 break
@@ -774,6 +774,11 @@ class SatelliteBase:
             self.settings.snd.awake_wav,
             mute_microphone=self.settings.mic.mute_during_awake_wav,
         )
+
+    async def trigger_played(self) -> None:
+        """Called when audio stopped playing"""
+        await run_event_command(self.settings.event.played)
+        await self.forward_event(Played().event())
 
     async def trigger_transcript(self, transcript: Transcript) -> None:
         """Called when speech-to-text text is received."""

--- a/wyoming_satellite/settings.py
+++ b/wyoming_satellite/settings.py
@@ -149,6 +149,7 @@ class EventSettings(ServiceSettings):
     streaming_stop: Optional[List[str]] = None
     detect: Optional[List[str]] = None
     detection: Optional[List[str]] = None
+    played: Optional[List[str]] = None
     transcript: Optional[List[str]] = None
     stt_start: Optional[List[str]] = None
     stt_stop: Optional[List[str]] = None


### PR DESCRIPTION
This exposes the Played event so it can run an external command (in addition to the event handler).
This is based on #69 and #72 and fixes #92.