### PR TITLE
bugfix: Remove double volume multiplier

### DIFF
--- a/wyoming_satellite/satellite.py
+++ b/wyoming_satellite/satellite.py
@@ -594,7 +594,6 @@ class SatelliteBase:
             for event in wav_to_events(
                 wav_path,
                 samples_per_chunk=self.settings.snd.samples_per_chunk,
-                volume_multiplier=self.settings.snd.volume_multiplier,
             ):
                 await self.event_to_snd(event)
         except Exception:


### PR DESCRIPTION
The two wave files follow the path:
`_play_wav >> wav_to_events >> event_to_snd` until `_snd_task_proc` where they will be threated like any other sound (AudioChunk) coming from server.

However, volume multiplier is applied at the `wav_to_events` step and at the `_snd_task_proc`.

This patch removes the volume from the event generation in the call to `wav_to_events` from `_play_wav` so it will applied only once in the event processing.
