### PR TITLE
additional requirement files in script/setup and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app
 
 COPY sounds/ ./sounds/
 COPY script/setup ./script/
-COPY setup.py requirements.txt MANIFEST.in ./
+COPY setup.py requirements.txt requirements_audio_enhancement.txt requirements_vad.txt MANIFEST.in ./
 COPY wyoming_satellite/ ./wyoming_satellite/
 
 RUN script/setup

--- a/script/setup
+++ b/script/setup
@@ -33,6 +33,10 @@ subprocess.check_call(
         "https://synesthesiam.github.io/prebuilt-apps/",
         "-r",
         str(_PROGRAM_DIR / "requirements.txt"),
+        "-r",
+        str(_PROGRAM_DIR / "requirements_audio_enhancement.txt"),
+        "-r",
+        str(_PROGRAM_DIR / "requirements_vad.txt"),
     ]
 )
 


### PR DESCRIPTION
As the `requirements.txt` file was split, those dependencies no longer work.

I believe it's best to have the scripts install all dependencies and advanced users can just ignore the setup and install manually if they don't want the whole package. 

This can help avoid some issues to be open.

Fix #107 
