### PR TITLE
Update README.md (mic delay after awake.wav)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ You can play a WAV file when the wake word is detected (locally or remotely), an
 
 If you want to play audio files other than WAV, use [event commands](#event-commands). Specifically, the `--detection-command` to replace `--awake-wav` and `--transcript-command` to replace `--done-wav`.
 
+#### Additonal mic + awake.wav configuration:
+* `--mic-seconds-to-mute-after-awake-wav 0.5` - delay (in seconds) after awake.wav is played to trigger capture of mic audio - default=0.5
+* `--mic-mute-during-awake-wav True` - True, if there should be any delay in mic capture after awake.wav is played - default=True
+
+If you notice your audio capture is starting late, try lowering or disabling this setting.
+
 ## Audio Enhancements
 
 Install the dependencies for webrtc:


### PR DESCRIPTION
`--mic-seconds-to-mute-after-awake-wav` being 0.5 by default was the single biggest factor into why I thought Whisper wasn't processing my text to speech correctly. Not complaining, just wanted to highlight it might be good for users to know this is defaulted to a large pause before speaking, so they don't fall into my same mistakes. I assume "after-awake-wav" means after the .wav file is completely played, right? Changing this to 0.1 really helped me, but obviously there are many use cases, not just my own.