### PR TITLE
Implement VAD functionality for WakeWordSatellite

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Audio will only be streamed to the server after the wake word has been detected.
 
 Once a wake word has been detected, it can not be detected again for several seconds (called the "refractory period"). You can change this with `--wake-refractory-seconds <SECONDS>`.
 
-Note that `--vad` is unnecessary when connecting to a local instance of openwakeword.
+Note that `--vad` is only used for wakeword detection when connection with a local openwakeword instance, not for STT after wakeword detection.
 
 ## Sounds
 

--- a/wyoming_satellite/__main__.py
+++ b/wyoming_satellite/__main__.py
@@ -296,9 +296,6 @@ async def main() -> None:
         _LOGGER.fatal("%s does not exist", args.done_wav)
         sys.exit(1)
 
-    if args.vad and (args.wake_uri or args.wake_command):
-        _LOGGER.warning("VAD is not used with local wake word detection")
-
     logging.basicConfig(
         level=logging.DEBUG if args.debug else logging.INFO, format=args.log_format
     )


### PR DESCRIPTION
I copied over the VAD implementation to be used together with the WakeWordSatellite. I decided to implement it here instead of in wyoming-openwakeword (https://github.com/rhasspy/wyoming-openwakeword/issues/16) for now. It does seem to work reasonably well and integrates fully with the standard VAD configuration options.

Wakeword detection gets a bit slower if this is used because it will have to run OWW on the whole VAD buffer, but that should also be the same in streaming mode. Perhaps there are better configuration options for the default case which I haven't found yet.