### PR TITLE
Change docs to suggest bookworm based Pi OS

### DIFF
--- a/docs/tutorial_2mic.md
+++ b/docs/tutorial_2mic.md
@@ -6,7 +6,7 @@ This tutorial should work for almost any Raspberry Pi and USB microphone. Audio 
 
 ## Install OS
 
-Follow instructions to [install Raspberry Pi OS](https://www.raspberrypi.com/software/). Under "Choose OS", pick "Raspberry Pi OS (other)" and "Raspberry Pi OS (Legacy, **64-bit**) Lite".
+Follow instructions to [install Raspberry Pi OS](https://www.raspberrypi.com/software/). Under "Choose OS", pick "Raspberry Pi OS (other)" and "Raspberry Pi OS (**64-bit**) Lite".
 
 When asking if you'd like to apply customization settings, choose "Edit Settings" and:
 

--- a/docs/tutorial_installer.md
+++ b/docs/tutorial_installer.md
@@ -4,7 +4,7 @@ Create a voice satellite using a Raspberry Pi 3+ and USB microphone and speakers
 
 ## Install OS
 
-Follow instructions to [install Raspberry Pi OS](https://www.raspberrypi.com/software/). Under "Choose OS", pick "Raspberry Pi OS (other)" and "Raspberry Pi OS (Legacy, **64-bit**) Lite".
+Follow instructions to [install Raspberry Pi OS](https://www.raspberrypi.com/software/). Under "Choose OS", pick "Raspberry Pi OS (other)" and "Raspberry Pi OS (**64-bit**) Lite".
 
 When asking if you'd like to apply customization settings, choose "Edit Settings" and:
 


### PR DESCRIPTION
Depends on https://github.com/rhasspy/wyoming-satellite/pull/165 and https://github.com/rhasspy/wyoming-satellite/pull/171 to function properly
It's my solution to the issue https://github.com/rhasspy/wyoming-satellite/issues/157
Since tflite-runtime-nightly no longer provides any wheels for bullseye based Pi OS (the Legacy one), and the last non nightly one that supports it is 2.13, which for me occasionally crashes the openwakeword service, I propose that new installations are done on bookworm based Pi OS (non-Legacy one).
I have a 2mic based satellite running it, the driver install went fine with the change in my other PR, and everything works perfectly.