### PR TITLE
Adjust compile threads for low memory boards when installing Respeaker driver

### DIFF
--- a/etc/install-respeaker-drivers.sh
+++ b/etc/install-respeaker-drivers.sh
@@ -43,12 +43,18 @@ mod='seeed-voicecard'
 src='./'
 kernel="$(uname -r)"
 marker='0.0.0'
+threads="$(getconf _NPROCESSORS_ONLN)"
+memory="$(LANG=C free -m|awk '/^Mem:/{print $2}')"
+
+if  [ "$memory" -le 512 ] && [ "$threads" -gt 2 ]; then
+threads=2
+fi
 
 mkdir -p "/usr/src/${mod}-${ver}"
 cp -a "${src}"/* "/usr/src/${mod}-${ver}/"
 
 dkms add -m "${mod}" -v "${ver}"
-dkms build -k "${kernel}" -m "${mod}" -v "${ver}" && {
+dkms build -k "${kernel}" -m "${mod}" -v "${ver}" -j "${threads}" && {
     dkms install --force -k "${kernel}" -m "${mod}" -v "${ver}"
 }
 

--- a/etc/install-respeaker-drivers.sh
+++ b/etc/install-respeaker-drivers.sh
@@ -46,7 +46,7 @@ marker='0.0.0'
 threads="$(getconf _NPROCESSORS_ONLN)"
 memory="$(LANG=C free -m|awk '/^Mem:/{print $2}')"
 
-if  [ "$memory" -le 512 ] && [ "$threads" -gt 2 ]; then
+if  [ "${memory}" -le 512 ] && [ "${threads}" -gt 2 ]; then
 threads=2
 fi
 


### PR DESCRIPTION
When running the latest, non-legacy Raspberry PI OS Lite version, it seems that some people with Pi Zero 2W boards are unable to install the respeaker driver due to running out of memory, see https://github.com/rhasspy/wyoming-satellite/issues/170#issuecomment-2153441822
Someone adjusted swap size to workaround this, and it compiled successfully.
In my less intrusive workaround, I've changed the script to compile the dkms module with half the threads if the board has less than 512MBs of main memory. This should lower the memory requirements and avoid OOM issues.