### PR TITLE
Build and push Docker image on tag

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,56 @@
+---
+name: Build and publish the docker image
+
+on:
+  push:
+    tags:
+    - "v[0-9]+.[0-9]+.[0-9]+"              # For releases, e.g. v1.2.0
+    - "v[0-9]+.[0-9]+.[0-9]+-[a-zA-Z0-9]+" # For prereleases, e.g. v1.3.0-alpha1
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # E.g. tag v1.2.0 produces 3 tags: '1.2.0', '1.2', and 'latest'
+          # https://github.com/docker/metadata-action?tab=readme-ov-file#semver
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5.3.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+...

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends avahi-utils
+    apt-get install --yes --no-install-recommends avahi-utils alsa-utils pulseaudio-utils pipewire-bin
 
 WORKDIR /app
 


### PR DESCRIPTION
Thank you for this awesome project! This PR adds support for docker image build&publish to the Github image registry, when a tag is pushed.

If e.g. tagging a commit as `v1.3.0`, this workflow will make the image available as:
- `ghcr.io/rhasspy/wyoming-satellite:1.3.0`
- `ghcr.io/rhasspy/wyoming-satellite:1.3`
- `ghcr.io/rhasspy/wyoming-satellite:latest`

I had built the [1.2.0 image for myself](https://github.com/mvitale1989/wyoming-satellite/tree/release-v1.2.0) (can be inspected with `docker pull ghcr.io/mvitale1989/wyoming-satellite:1.2.0-1`, with a slightly different tagging scheme) to use it in my k8s cluster, but it'd be great if this is done in the project repo itself.