### PR TITLE
Added support to skip TTS playback

### DIFF
--- a/wyoming_satellite/__main__.py
+++ b/wyoming_satellite/__main__.py
@@ -96,6 +96,7 @@ async def main() -> None:
     # Sound output
     parser.add_argument("--snd-uri", help="URI of Wyoming sound service")
     parser.add_argument("--snd-command", help="Program to run for sound output")
+    parser.add_argument("--snd-tts-skip-playback", help="Skip TTS playback. Defaults False")
     parser.add_argument(
         "--snd-command-rate",
         type=int,
@@ -396,6 +397,7 @@ async def main() -> None:
             volume_multiplier=args.snd_volume_multiplier,
             awake_wav=args.awake_wav,
             done_wav=args.done_wav,
+            tts_skip_playback=args.snd_tts_skip_playback
         ),
         event=EventSettings(
             uri=args.event_uri,

--- a/wyoming_satellite/satellite.py
+++ b/wyoming_satellite/satellite.py
@@ -269,7 +269,8 @@ class SatelliteBase:
             forward_event = False
         elif AudioChunk.is_type(event.type):
             # TTS audio
-            await self.event_to_snd(event)
+            if not self.settings.snd.tts_skip_playback:
+                await self.event_to_snd(event)
             forward_event = False
         elif AudioStart.is_type(event.type):
             # TTS started

--- a/wyoming_satellite/settings.py
+++ b/wyoming_satellite/settings.py
@@ -83,6 +83,9 @@ class SndSettings(ServiceSettings):
     done_wav: Optional[str] = None
     """Path to WAV file played after voice command is recognized."""
 
+    tts_skip_playback: Optional[bool] = False
+    """Skip TTS playback.  Defaults to False."""
+
     rate: int = 22050
     """Sample rate of output audio (hertz)"""
 


### PR DESCRIPTION
In my environment, I am using an rpi satellite with usb speaker + mic, and have external (sonos) speakers throughout the house.  I wanted my satellite to play awake/done sounds using the locally attached speaker, but have the option to omit the TTS playback from the local speaker, and instead use the synthesize command to have the Sonos speakers announce the TTS response.

There was no way to do this previously, so i added optional support for it, which defaults to off, so as not to confuse anyone or break any existing implementations.