### PR TITLE
Added additional LED indication for ReSpeaker 2Mic HAT

### DIFF
--- a/examples/2mic_service.py
+++ b/examples/2mic_service.py
@@ -13,8 +13,8 @@ import spidev
 from wyoming.asr import Transcript
 from wyoming.event import Event
 from wyoming.satellite import (
-    RunSatellite,
     PauseSatellite,
+    RunSatellite,
     SatelliteConnected,
     SatelliteDisconnected,
     StreamingStarted,
@@ -23,6 +23,10 @@ from wyoming.satellite import (
 from wyoming.server import AsyncEventHandler, AsyncServer
 from wyoming.vad import VoiceStarted
 from wyoming.wake import Detection
+from wyoming.tts import Synthesize
+from wyoming.audio import AudioStop
+from wyoming.snd import Played
+from wyoming.error import Error
 
 _LOGGER = logging.getLogger()
 
@@ -84,6 +88,8 @@ _DARK_RED = (50, 0, 0)
 _YELLOW = (255, 255, 0)
 _BLUE = (0, 0, 255)
 _GREEN = (0, 255, 0)
+_CYAN = (0, 255, 255)
+_PURPLE = (128, 0, 128)
 
 
 class LEDsEventHandler(AsyncEventHandler):
@@ -101,6 +107,7 @@ class LEDsEventHandler(AsyncEventHandler):
         self.cli_args = cli_args
         self.client_id = str(time.monotonic_ns())
         self.leds = leds
+        self.previous_event = None
 
         _LOGGER.debug("Client connected: %s", self.client_id)
 
@@ -121,8 +128,6 @@ class LEDsEventHandler(AsyncEventHandler):
             self.color(_BLACK)
         elif RunSatellite.is_type(event.type):
             self.color(_BLACK)
-        elif PauseSatellite.is_type(event.type):
-            self.color(_DARK_RED)
         elif SatelliteDisconnected.is_type(event.type):
             self.color(_DARK_RED)
         elif SatelliteConnected.is_type(event.type):
@@ -132,6 +137,23 @@ class LEDsEventHandler(AsyncEventHandler):
                 await asyncio.sleep(0.3)
                 self.color(_BLACK)
                 await asyncio.sleep(0.3)
+        elif PauseSatellite.is_type(event.type):
+            self.color(_DARK_RED)
+        elif Error.is_type(event.type):
+            # Flash
+            for _ in range(3):
+                self.color(_PURPLE)
+                await asyncio.sleep(0.3)
+                self.color(_BLACK)
+                await asyncio.sleep(0.3)
+        # While the assist is responding with audio, the LEDs should be cyan
+        elif Synthesize.is_type(event.type):
+            self.color(_CYAN)
+        # When the assist is done responding with audio, the LEDs should be black
+        elif Played.is_type(event.type) and AudioStop.is_type(self.previous_event):
+            self.color(_BLACK)
+
+        self.previous_event = event.type
 
         return True
 

--- a/examples/2mic_service.py
+++ b/examples/2mic_service.py
@@ -14,6 +14,7 @@ from wyoming.asr import Transcript
 from wyoming.event import Event
 from wyoming.satellite import (
     RunSatellite,
+    PauseSatellite,
     SatelliteConnected,
     SatelliteDisconnected,
     StreamingStarted,
@@ -79,6 +80,7 @@ async def main() -> None:
 _BLACK = (0, 0, 0)
 _WHITE = (255, 255, 255)
 _RED = (255, 0, 0)
+_DARK_RED = (50, 0, 0)
 _YELLOW = (255, 255, 0)
 _BLUE = (0, 0, 255)
 _GREEN = (0, 255, 0)
@@ -119,6 +121,10 @@ class LEDsEventHandler(AsyncEventHandler):
             self.color(_BLACK)
         elif RunSatellite.is_type(event.type):
             self.color(_BLACK)
+        elif PauseSatellite.is_type(event.type):
+            self.color(_DARK_RED)
+        elif SatelliteDisconnected.is_type(event.type):
+            self.color(_DARK_RED)
         elif SatelliteConnected.is_type(event.type):
             # Flash
             for _ in range(3):
@@ -126,8 +132,6 @@ class LEDsEventHandler(AsyncEventHandler):
                 await asyncio.sleep(0.3)
                 self.color(_BLACK)
                 await asyncio.sleep(0.3)
-        elif SatelliteDisconnected.is_type(event.type):
-            self.color(_RED)
 
         return True
 


### PR DESCRIPTION
Glow dim red when in disconnected or paused state. Flash purple where there is an error event and Cyan while Assist is playing the Text to Speech audio (response).

Credit goes to [MrSco](https://github.com/rhasspy/wyoming-satellite/issues/63#issuecomment-1906800897) and [tonyis49](https://github.com/rhasspy/wyoming-satellite/issues/149#issuecomment-2311934797)