### PR TITLE
Install the wyoming_satellite.utils module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,5 +57,5 @@ zip-safe  = true
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["wyoming_satellite"]
+include = ["wyoming_satellite", "wyoming_satellite.utils"]
 exclude = ["tests", "tests.*"]


### PR DESCRIPTION
Ever since moving to pyproject.toml the utils module was not included in the build anymore, which led to import errors.