### PR TITLE
Add Docker Support and Documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends avahi-utils
+    apt-get install --yes --no-install-recommends avahi-utils alsa-utils
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ENV LANG C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install --yes --no-install-recommends avahi-utils alsa-utils
+    apt-get install --yes --no-install-recommends avahi-utils alsa-utils && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
I'm setting up a local voice assistant for home automation and noticed that, unlike other Wyoming services (Whisper, Piper, OpenWakeWord), there is no official Docker Hub image for Wyoming Satellite. This creates some confusion for users coming from Home Assistant, where containerized deployments are common.

This PR introduces:
- Documentation on how to deploy a Wyoming Satellite instance using Docker.
- Examples for both `docker run` and `docker-compose`.
- Installation of `alsa-utils` within the container to ensure audio-related commands work out of the box.

### Important
For this to be fully functional, **the image built by this repository's Dockerfile needs to be published to Docker Hub as `rhasspy/wyoming-satellite`**. 

### Next Steps
If this PR is well received and an official image is made available, I’d be happy to contribute further improvements. To begin, I would restructure the documentation to better clarify this repository’s role within the Wyoming ecosystem, ensuring users have a clear understanding of how different services interact. For example, rather than including installation instructions for Wyoming OpenWakeWord, we could simply link to its repository, reducing confusion for users who are still getting familiar with the system.

Additionally, I could set up a GitHub Actions workflow to automate the build and push process for the Docker image, ensuring that updates are automatically published to `ghcr.io` or Docker Hub whenever a commit or tag is pushed to the `master` branch. Let me know.