### PR TITLE
Update pyproject.toml to fix broken build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,5 +57,5 @@ zip-safe  = true
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["wyoming_satellite"]
+include = ["wyoming_satellite*"]
 exclude = ["tests", "tests.*"]


### PR DESCRIPTION
This change fixes the build for wyoming-satellite
At the moment, the utils directory is not included in the build, so building from source results in a broken build that fails with the following error:  
```
>>> import wyoming_satellite
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/to/site-packages/wyoming_satellite/__init__.py", line 6, in <module>
    from .satellite import (
  File "/path/to/site-packages/wyoming_satellite/satellite.py", line 39, in <module>
    from .utils import (
ModuleNotFoundError: No module named 'wyoming_satellite.utils'
```  

To reproduce, simply try to install from source and try to import:
uv pip install "git+https://github.com/rhasspy/wyoming-satellite.git"