### PR TITLE
Use 2 threads for DKMS on systen updates as well

### DIFF
--- a/etc/install-respeaker-drivers.sh
+++ b/etc/install-respeaker-drivers.sh
@@ -47,14 +47,14 @@ threads="$(getconf _NPROCESSORS_ONLN)"
 memory="$(LANG=C free -m|awk '/^Mem:/{print $2}')"
 
 if  [ "${memory}" -le 512 ] && [ "${threads}" -gt 2 ]; then
-threads=2
+    sed -i '$a\MAKE[0]="'\''make'\'' -j2"' "${src}/dkms.conf"
 fi
 
 mkdir -p "/usr/src/${mod}-${ver}"
 cp -a "${src}"/* "/usr/src/${mod}-${ver}/"
 
 dkms add -m "${mod}" -v "${ver}"
-dkms build -k "${kernel}" -m "${mod}" -v "${ver}" -j "${threads}" && {
+dkms build -k "${kernel}" -m "${mod}" -v "${ver}" && {
     dkms install --force -k "${kernel}" -m "${mod}" -v "${ver}"
 }
 


### PR DESCRIPTION
In my previous PR, I've added a change that would make DKMS compile the respeaker driver using 2 threads instead of 4 on boards like Pi Zero 2W. However, this would only apply during the initial install.
If the user attempted to upgrade the system, and there was an update to the kernel, DKMS would try to use 4 threads like before and result in a system lockup.
This change will modify the `dkms.conf` file so that DKMS always compiles the driver with 2 threads, even on updates, when the board is detected having too little memory (so the same as previous PR).